### PR TITLE
The enhancement for the branch sdk_501

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, install the npm package and link it to your Android and iOS projects with
 1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
 2. In the `Downloading the SDK` section of the official integration guide:
 - If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow the integration guide
-- If you manual download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK via Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
+- If you manual download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK files via Xcode, be sure place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ First, install the npm package and link it to your Android and iOS projects with
 ```
 ### iOS Setup
 1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
-2. In `Downloading the SDK` section of the official integration guide:
-- If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow all of the 
-- If you download the Line SDK by manual download ( in the sub section `Download from the "Downloads" page` ), before linking the SDK via Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
+2. In the `Downloading the SDK` section of the official integration guide:
+- If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow the integration guide
+- If you manual download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK via Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ First, install the npm package and link it to your Android and iOS projects with
   react-native link react-native-line-sdk
 ```
 ### iOS Setup
-Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
+1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
+2. In `Downloading the SDK` section of the official integration guide:
+- If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow all of the 
+- If you download the Line SDK by manual download ( in the sub section `Download from the "Downloads" page` ), before continue to do anything with Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, install the npm package and link it to your Android and iOS projects with
 1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
 2. In `Downloading the SDK` section of the official integration guide:
 - If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow all of the 
-- If you download the Line SDK by manual download ( in the sub section `Download from the "Downloads" page` ), before continue to do anything with Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
+- If you download the Line SDK by manual download ( in the sub section `Download from the "Downloads" page` ), before linking the SDK via Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, install the npm package and link it to your Android and iOS projects with
 1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
 2. In the `Downloading the SDK` section of the official integration guide:
 - If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow the integration guide
-- If you manual download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK files via Xcode, be sure place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
+- If you manually download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK files via Xcode, be sure place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/ios/LineLoginManager.xcodeproj/project.pbxproj
+++ b/ios/LineLoginManager.xcodeproj/project.pbxproj
@@ -199,7 +199,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../../ios/Frameworks",
-					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/Frameworks",
+					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/LineSDK",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -220,7 +220,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../../ios/Frameworks",
-					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/Frameworks",
+					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/LineSDK",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/LineLoginManager.xcodeproj/project.pbxproj
+++ b/ios/LineLoginManager.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -196,7 +197,10 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../ios/Frameworks",
+					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -214,7 +218,10 @@
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../ios/Frameworks",
+					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,


### PR DESCRIPTION
Hello Xiaoming,

Consider the [`'LineSDK/LineSDK.h' file not found`](https://github.com/xmartlabs/react-native-line/issues/17) issue still happened when people integrate this package with iOS native code. We here propose this PR for the following purposes:
- Make no compile error when people get the LineSDK framework via Cocoapods 
- Enhance the description on readme so people who get the LineSDK framework manually can clearly know where they should place the SDK files

Here is the suggestion about how to verify the fix in this PR:

- Scenario A -  Integrate the package with Cocoapods
  - a. Create a new react-native project
  - b. Execute `npm install --save ekohe/react-native-line#fix/sdk_501_ios_link` for get the library with this change or add `"react-native-line-sdk": "github:ekohe/react-native-line#fix/sdk_501_ios_link",` in `package.json` and execute `npm istall`
  - c. Execute `react-native link react-native-line-sdk`
  - d. Follow the rest of the instruction in [`iOS setup`](https://github.com/ekohe/react-native-line/tree/fix/sdk_501_ios_link#ios-setup), make sure get the `LineSDK` via Cocoapods
  - e. Try compile with Xcode and see if any problem occurred

- Scenario B -  Integrate the package with manually download the LineSDK
  - a. ~ c. same as the Scenario A
  - d. Follow the rest of the instruction in [`iOS setup`](https://github.com/ekohe/react-native-line/tree/fix/sdk_501_ios_link#ios-setup), make sure get the `LineSDK` via manually download
  - e. Try compile with Xcode and see if any problem occurred


Please feel free to reply here if any problem/question/suggestion, thank you.

Best wishes,